### PR TITLE
upgrade centos-6 to 1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Pre-baked images for RPM and DEB package building. [fpm](https://github.com/jordansissel/fpm) is included!
 
-Centos 5 and 6 images are stuck (and will be probably stuck forever) to fpm 1.4.0 because of system limitations.
+Centos 5 images are stuck (and will be probably stuck forever) to fpm 1.4.0 because of system limitations.
 All other images should be updated to the latest FPM version, currently: **1.8.1**.
 
 ## what does this do?

--- a/fwd-centos-6/Dockerfile
+++ b/fwd-centos-6/Dockerfile
@@ -1,7 +1,22 @@
 FROM centos:6
 MAINTAINER Alan Franzoni <username@franzoni.eu>
-RUN yum clean metadata && yum -y update && yum -y install ruby ruby-devel rubygems libffi libffi-devel gnupg2 @"Development Tools" @Base rsync
-RUN gem install json -v 1.8.3
-RUN gem install fpm -v 1.4.0
-ADD files/etc/rpm/macros.fwd /etc/rpm/macros.fwd
-RUN yum clean all
+
+ENV PATH /opt/rh/ruby193/root/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+ENV PKG_CONFIG_PATH /opt/rh/ruby193/root/usr/lib64/pkgconfig
+ENV LD_LIBRARY_PATH /opt/rh/ruby193/root/usr/lib64
+
+RUN yum clean metadata \
+ && yum -y update \
+ && yum install -y centos-release-scl \
+ && yum -y install \
+    @Base \
+    @"Development Tools" \
+    gnupg2 \
+    libffi \
+    libffi-devel \
+    rsync \
+    ruby193 \
+    ruby193-ruby-devel \
+ && yum clean all
+RUN gem install --no-ri --no-rdoc fpm -v 1.8.1
+COPY files/etc/rpm/macros.fwd /etc/rpm/macros.fwd


### PR DESCRIPTION
Uses ruby193 from [SCL](https://wiki.centos.org/AdditionalResources/Repositories/SCL) to install fpm 1.8.1

