### PR TITLE
Fix: avoid 'apt-get update' failure on debian stretch

### DIFF
--- a/fwd-debian-stretch/Dockerfile
+++ b/fwd-debian-stretch/Dockerfile
@@ -4,6 +4,6 @@ COPY 80-acquire-retries /etc/apt/apt.conf.d/
 RUN apt-get update && apt-get -y install apt-transport-https curl gnupg2 rubygems-integration ruby-dev ruby build-essential rsync && apt-get -y dist-upgrade && apt-get clean && rm -f /var/lib/apt/lists/* ; rm -f /var/lib/apt/lists/partial/*
 RUN gem install fpm -v 1.9.3
 RUN curl https://www.franzoni.eu/keys/D401AB61.txt | apt-key add -
-RUN echo "deb https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie main" > /etc/apt/sources.list.d/apt-current-v1.list
+RUN echo "deb https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch stretch main" > /etc/apt/sources.list.d/apt-current-v1.list
 RUN apt-get -y update  ; apt-get -y install apt-current && apt-get clean && rm -f /var/lib/apt/lists/* ; rm -f /var/lib/apt/lists/partial/*
 RUN /bin/echo -e "MAXDELTA=3600\nCLEANUP_DOWNLOADED_PACKAGES=\"true\"\nCLEANUP_DOWNLOADED_LISTS=\"true\"\n" > /etc/apt-current.conf


### PR DESCRIPTION
This change avoids the following failure:

```shell
$ docker run -it --rm alanfranz/fpm-within-docker:debian-stretch bash
root@f013d71d45fd:/# apt-get update
Ign:1 http://deb.debian.org/debian stretch InRelease
Get:2 http://security.debian.org stretch/updates InRelease [63.0 kB]
Get:3 http://deb.debian.org/debian stretch-updates InRelease [91.0 kB]
Get:4 http://deb.debian.org/debian stretch Release [118 kB]           
Get:5 http://deb.debian.org/debian stretch Release.gpg [2434 B]
Get:6 http://security.debian.org stretch/updates/main amd64 Packages [415 kB]
Get:7 http://deb.debian.org/debian stretch-updates/main amd64 Packages.diff/Index [2704 B]
Get:8 http://deb.debian.org/debian stretch-updates/main amd64 Packages 2018-01-29-2029.34.pdiff [2394 B]
Get:9 http://deb.debian.org/debian stretch-updates/main amd64 Packages 2018-02-11-2045.46.pdiff [332 B]
Get:9 http://deb.debian.org/debian stretch-updates/main amd64 Packages 2018-02-11-2045.46.pdiff [332 B]
Ign:10 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie InRelease
Get:11 http://deb.debian.org/debian stretch/main amd64 Packages [9531 kB]
Ign:12 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie Release
Ign:13 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main amd64 Packages
Ign:14 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main all Packages
Ign:13 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main amd64 Packages
Ign:14 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main all Packages
Ign:13 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main amd64 Packages
Ign:14 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main all Packages
Ign:13 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main amd64 Packages
Ign:14 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main all Packages
Ign:13 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main amd64 Packages
Ign:14 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main all Packages
Err:13 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main amd64 Packages
  404  Not Found
Ign:14 https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie/main all Packages
Fetched 10.2 MB in 2s (4741 kB/s)
Reading package lists... Done
W: The repository 'https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch jessie Release' does not have a Release file.
N: Data from such a repository can't be authenticated and is therefore potentially dangerous to use.
N: See apt-secure(8) manpage for repository creation and user configuration details.
E: Failed to fetch https://dl.bintray.com/alanfranz/apt-current-v1-debian-stretch/dists/jessie/main/binary-amd64/Packages  404  Not Found
E: Some index files failed to download. They have been ignored, or old ones used instead.
root@f013d71d45fd:/# echo $?
100
```
